### PR TITLE
Change prop name to avoid conflict with Project.getBuildDir()

### DIFF
--- a/chapter09/listing_09_01-04-ant-import/gradle/build.gradle
+++ b/chapter09/listing_09_01-04-ant-import/gradle/build.gradle
@@ -12,9 +12,9 @@ init {
     }
 }
 
-ext.buildDir = '../ant/build'
-ant.properties.build = "$buildDir/classes"
-ant.properties.dist = "$buildDir/libs"
+ext.antBuildDir = '../ant/build'
+ant.properties.build = "$antBuildDir/classes"
+ant.properties.dist = "$antBuildDir/libs"
 
 task sourcesJar(type: Jar) {
     baseName = 'my-app'


### PR DESCRIPTION
In this script, we create a property pointing to the ant build directory:
ext.buildDir = '../ant/build'

Then refer to it subsequently without the "ext" prefix:
ant.properties.build = "$buildDir/classes"
ant.properties.dist = "$buildDir/libs"

The problem is that "$buildDir" is referencing Project.getBuildDir() [1], not our property. We can avoid this conflict by renaming our property.

[1] https://gradle.org/docs/current/javadoc/org/gradle/api/Project.html#getBuildDir%28%29