### PR TITLE
Correct the URL used to download JSHint

### DIFF
--- a/chapter11/listing_11_06-07-todo-js-code-quality/gradle/jsCodeQuality.gradle
+++ b/chapter11/listing_11_06-07-todo-js-code-quality/gradle/jsCodeQuality.gradle
@@ -3,7 +3,7 @@ repositories {
 
     ivy {
         name 'JSHint'
-        url 'https://github.com/bmuschko/gradle-in-action-source/tree/master/chapter11/listing_11_06-07-todo-js-code-quality/ivy-repo'
+        url 'https://raw.githubusercontent.com/bmuschko/gradle-in-action-source/master/chapter11/listing_11_06-07-todo-js-code-quality/ivy-repo'
         layout 'pattern', {
             artifact '[organization]/[module]/[module]-[revision](.[classifier]).[ext]'
         }


### PR DESCRIPTION
The URL used to download JSHint from github (https://github.com/bmuschko/gradle-in-action-source/tree/master/chapter11/listing_11_06-07-todo-js-code-quality/ivy-repo/...) in Listing 6-7 in Chapter 11 points the html document for the js file, and not the js file itself.
Because of that running `gradle jsHint` fails with a lot of warnings since the html is interpreted as js.

I updated `jsCodeQuality.gradle` to use raw.githubusercontent.com instead, which seems to work as intended.